### PR TITLE
feat: add the debug parameter to enable verbose logs

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -10,6 +10,8 @@ path = "github.com/hugomods/hugopress"
 [params]
 
 [params.hugopress]
+debug = true
+
 [params.hugopress.modules.hello]
 [params.hugopress.modules.hello.attributes.document]
 [params.hugopress.modules.hello.attributes.body]

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,2 +1,5 @@
 [module.hugoVersion]
 min = "0.110.0"
+
+[params.hugopress]
+debug = false

--- a/layouts/partials/hugopress/functions/render-attributes.html
+++ b/layouts/partials/hugopress/functions/render-attributes.html
@@ -8,6 +8,9 @@
     {{- warnf "[hugopress] [%s] attribute does't exist: layouts/partials/%s.html" .module .partial }}
     {{- continue }}
   {{- end }}
+  {{- if site.Params.hugopress.debug }}
+    {{- warnf "[hugopress] [%s] rendering attribute: %q." .module .name }}
+  {{- end }}
   {{- if .cacheable }}
     {{- $attrs = partialCached .partial (dict "Page" $page) }}
   {{- else }}

--- a/layouts/partials/hugopress/functions/render-hooks.html
+++ b/layouts/partials/hugopress/functions/render-hooks.html
@@ -15,6 +15,9 @@
     {{- warnf "[hugopress] [%s] hook does't exist: layouts/partials/%s.html" .module .partial }}
     {{- continue }}
   {{- end }}
+  {{- if site.Params.hugopress.debug }}
+    {{- warnf "[hugopress] [%s] rendering hook: %q." .module .name }}
+  {{- end }}
   {{- if .cacheable }}
     {{- partialCached .partial $ctx }}
   {{- else }}

--- a/layouts/partials/hugopress/functions/settings.html
+++ b/layouts/partials/hugopress/functions/settings.html
@@ -3,14 +3,21 @@
 {{- $attributes := newScratch }}
 {{- range $moduleName, $module := site.Params.HugoPress.Modules }}
   {{- if or $module.disable $module.disabled }}
-    {{ continue }}
+    {{- if site.Params.hugopress.debug }}
+      {{- warnf "[hugopress] [%s] was disabled." $moduleName }}
+    {{- end }}
+    {{- continue }}
   {{- end }}
   {{- with .Hooks }}
     {{- range $name, $option := . }}
       {{- if or $option.disable $option.disabled }}
+        {{- if site.Params.hugopress.debug }}
+          {{- warnf "[hugopress] [%s] hook %q was disabled." $moduleName $name }}
+        {{- end }}
         {{- continue }}
       {{- end }}
       {{- $option = merge $option (dict
+        "name" $name
         "module" $moduleName
         "partial" (printf "hugopress/modules/%s/hooks/%s" $moduleName $name))
       }}
@@ -20,9 +27,13 @@
   {{- with .Attributes }}
     {{- range $name, $option := . }}
       {{- if or $option.disable $option.disabled }}
+        {{- if site.Params.hugopress.debug }}
+          {{- warnf "[hugopress] [%s] attribute %q was disabled." $moduleName $name }}
+        {{- end }}
         {{- continue }}
       {{- end }}
       {{- $option = merge $option (dict
+        "name" $name
         "module" $moduleName
         "partial" (printf "hugopress/modules/%s/attributes/%s" $moduleName $name))
       }}


### PR DESCRIPTION
To enable debug/verbose mode by setting the following configuration.

```yaml
params:
  hugopress:
    debug: true
```

Close #23