### PR TITLE
feat: add the cache_site_param_key to cache partial against site parameter

### DIFF
--- a/layouts/partials/hugopress/functions/render-hooks.html
+++ b/layouts/partials/hugopress/functions/render-hooks.html
@@ -19,6 +19,8 @@
       {{- partialCached .partial $ctx (index (apply (slice 0) .cache_key) 0) }}
     {{- else if ne .cache_param_key nil }}
       {{- partialCached .partial $ctx (index $page.Params .cache_param_key) }}
+    {{- else if ne .cache_site_param_key nil }}
+      {{- partialCached .partial $ctx (index site.Params .cache_site_param_key) }}
     {{- else }}
       {{- partialCached .partial $ctx }}
     {{- end }}

--- a/layouts/partials/hugopress/functions/settings.html
+++ b/layouts/partials/hugopress/functions/settings.html
@@ -26,6 +26,13 @@
         "module" $moduleName
         "partial" $partial)
       }}
+      {{/* Transform cache keys only once. */}}
+      {{- range slice "cache_param_key" "cache_site_param_key" }}
+        {{- $cacheKey := . }}
+        {{- with index $option $cacheKey }}
+          {{- $option = merge $option (dict $cacheKey (split . ".")) }}
+        {{- end }}
+      {{- end }}
       {{- $hooks.Add $name (slice $option) }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Support nested parameters, separated by dot, such as `foo.bar.fizz`